### PR TITLE
Use only one ICMP manager instance.

### DIFF
--- a/rpp
+++ b/rpp
@@ -88,8 +88,7 @@ class RiemannPuppetPing
     end
   end
 
-  def ping_everyone(entries)
-    manager = ICMP4EM::Manager.new :retries => @retries, :timeout => @timeout
+  def ping_everyone(entries, manager)
     entries.each do |entry|
       next unless pingable? entry[:host]
       begin
@@ -104,9 +103,10 @@ class RiemannPuppetPing
 
   def serve_forever
     EM.run do
-      ping_everyone(dir_list)
+      manager = ICMP4EM::Manager.new :retries => @retries, :timeout => @timeout
+      ping_everyone(dir_list, manager)
       EM.add_periodic_timer(@interval) do
-        ping_everyone(dir_list)
+        ping_everyone(dir_list, manager)
       end
     end
   end


### PR DESCRIPTION
For some reason, the ICMP manager instances may not be garbage-collected
correctly. To avoid leaking the attached file descriptors, we use only
one instance instead. This may hide a more serious problem (garbage
collection may not happen because callbacks are not invoked on some edge
case).